### PR TITLE
Fixed Stanford dictionary url

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ http://ad-publications.informatik.uni-freiburg.de/CIKM_freebase_qa_BH_2015.pdf
 It uses a sqlite database of search strings, wiki URLs and
 the probability of the URL given the string. The dataset is located at
 
-	http://www-nlp.stanford.edu/pubs/crosswikis-data.tar.bz2/dictionary.bz2
+	http://nlp.stanford.edu/data/crosswikis-data.tar.bz2/dictionary.bz2	
+
+And more information can be found at
+
+	http://nlp.stanford.edu/data/crosswikis-data.tar.bz2/
 
 The database will be created automatically.
 To initialize the database, run 


### PR DESCRIPTION
Old URL leads to a 404.
Swapped w/new URL, and added a link to Stanford's README.